### PR TITLE
Short ammeter in LVS netlist

### DIFF
--- a/xschem/Input_Stage_OA1.sch
+++ b/xschem/Input_Stage_OA1.sch
@@ -142,7 +142,7 @@ sa=0 sb=0 sd=0
 model=nfet_01v8_lvt
 spiceprefix=X
 }
-C {devices/ammeter.sym} 670 -260 0 0 {name=VISink}
+C {devices/ammeter.sym} 670 -260 0 0 {name=VISink lvs_ignore=short}}
 C {sky130_fd_pr/pfet_01v8_lvt.sym} 600 -630 0 1 {name=M6
 L=5
 W=20
@@ -171,10 +171,10 @@ sa=0 sb=0 sd=0
 model=pfet_01v8_lvt
 spiceprefix=X
 }
-C {devices/ammeter.sym} 580 -530 0 0 {name=VD1}
-C {devices/ammeter.sym} 760 -530 0 1 {name=VID2}
-C {devices/ammeter.sym} 970 -270 0 0 {name=VID1}
-C {devices/ammeter.sym} 970 -530 0 0 {name=VID3}
+C {devices/ammeter.sym} 580 -530 0 0 {name=VD1 lvs_ignore=short}}
+C {devices/ammeter.sym} 760 -530 0 1 {name=VID2 lvs_ignore=short}}
+C {devices/ammeter.sym} 970 -270 0 0 {name=VID1 lvs_ignore=short}}
+C {devices/ammeter.sym} 970 -530 0 0 {name=VID3 lvs_ignore=short}}
 C {devices/iopin.sym} 510 -360 0 1 {name=p3 lab=VINN}
 C {devices/iopin.sym} 840 -360 0 0 {name=p5 lab=VINP}
 C {devices/spice_probe.sym} 510 -360 0 0 {name=p12 attrs=""}
@@ -184,7 +184,7 @@ C {devices/spice_probe.sym} 990 -380 0 0 {name=p2 attrs=""}
 C {devices/iopin.sym} 970 -710 0 0 {name=p4 lab=VDD}
 C {devices/iopin.sym} 970 -130 0 0 {name=p6 lab=VSS}
 C {devices/iopin.sym} 500 -180 0 1 {name=p7 lab=VBIAS}
-C {devices/ammeter.sym} 560 -180 3 0 {name=VIBIAS}
+C {devices/ammeter.sym} 560 -180 3 0 {name=VIBIAS lvs_ignore=short}}
 C {sky130_fd_pr/nfet_05v0_nvt.sym} 560 -440 0 0 {name=M10
 L=2
 W=1
@@ -255,7 +255,7 @@ sa=0 sb=0 sd=0
 model=pfet_g5v0d10v5
 spiceprefix=X
 }
-C {devices/ammeter.sym} 880 -710 1 0 {name=VIVDD}
+C {devices/ammeter.sym} 880 -710 1 0 {name=VIVDD lvs_ignore=short}}
 C {lab_pin.sym} 900 -510 0 1 {name=p8 sig_type=std_logic lab=VSS}
 C {sky130_fd_pr/cap_mim_m3_1.sym} 850 -550 0 0 {name=C1 model=cap_mim_m3_1 W=10 L=10 MF=15 spiceprefix=X}
 C {sky130_fd_pr/res_high_po_0p69.sym} 900 -470 1 0 {name=R2

--- a/xschem/Input_Stage_OA2.sch
+++ b/xschem/Input_Stage_OA2.sch
@@ -139,7 +139,7 @@ sa=0 sb=0 sd=0
 model=nfet_01v8_lvt
 spiceprefix=X
 }
-C {devices/ammeter.sym} -20 140 0 0 {name=VISink}
+C {devices/ammeter.sym} -20 140 0 0 {name=VISink lvs_ignore=short}}
 C {sky130_fd_pr/pfet_01v8_lvt.sym} -90 -230 0 1 {name=M6
 L=5
 W=20
@@ -168,10 +168,10 @@ sa=0 sb=0 sd=0
 model=pfet_01v8_lvt
 spiceprefix=X
 }
-C {devices/ammeter.sym} -110 -130 0 0 {name=VD1}
-C {devices/ammeter.sym} 70 -130 0 1 {name=VID2}
-C {devices/ammeter.sym} 280 130 0 0 {name=VID1}
-C {devices/ammeter.sym} 280 -130 0 0 {name=VID3}
+C {devices/ammeter.sym} -110 -130 0 0 {name=VD1 lvs_ignore=short}}
+C {devices/ammeter.sym} 70 -130 0 1 {name=VID2 lvs_ignore=short}}
+C {devices/ammeter.sym} 280 130 0 0 {name=VID1 lvs_ignore=short}}
+C {devices/ammeter.sym} 280 -130 0 0 {name=VID3 lvs_ignore=short}}
 C {devices/iopin.sym} -180 40 0 1 {name=p3 lab=VINN}
 C {devices/iopin.sym} 150 40 0 0 {name=p5 lab=VINP}
 C {devices/spice_probe.sym} -180 40 0 0 {name=p12 attrs=""}
@@ -181,7 +181,7 @@ C {devices/spice_probe.sym} 300 20 0 0 {name=p2 attrs=""}
 C {devices/iopin.sym} 280 -310 0 0 {name=p4 lab=VDD}
 C {devices/iopin.sym} 280 270 0 0 {name=p6 lab=VSS}
 C {devices/iopin.sym} -150 220 0 1 {name=p7 lab=VBIAS}
-C {devices/ammeter.sym} -90 220 3 0 {name=VIBIAS}
+C {devices/ammeter.sym} -90 220 3 0 {name=VIBIAS lvs_ignore=short}}
 C {sky130_fd_pr/nfet_05v0_nvt.sym} -130 -40 0 0 {name=M10
 L=2
 W=1
@@ -252,7 +252,7 @@ sa=0 sb=0 sd=0
 model=pfet_g5v0d10v5
 spiceprefix=X
 }
-C {devices/ammeter.sym} 190 -310 1 0 {name=VIVDD}
+C {devices/ammeter.sym} 190 -310 1 0 {name=VIVDD lvs_ignore=short}}
 C {sky130_fd_pr/cap_mim_m3_1.sym} 160 -150 0 0 {name=C1 model=cap_mim_m3_1 W=10 L=10 MF=15 spiceprefix=X}
 C {lab_pin.sym} 210 -110 0 1 {name=p8 sig_type=std_logic lab=VSS}
 C {sky130_fd_pr/res_high_po_0p69.sym} 210 -70 1 0 {name=R1

--- a/xschem/Input_Stage_v1.sch
+++ b/xschem/Input_Stage_v1.sch
@@ -92,9 +92,9 @@ lab=#net5}
 N 10 100 60 100 {
 lab=#net5}
 C {devices/iopin.sym} -360 30 0 1 {name=p3 lab=VINP}
-C {devices/ammeter.sym} -160 -250 0 0 {name=VI13}
-C {devices/ammeter.sym} 150 -130 0 0 {name=VI2}
-C {devices/ammeter.sym} -160 -40 0 0 {name=VI3}
+C {devices/ammeter.sym} -160 -250 0 0 {name=VI13 lvs_ignore=short}}
+C {devices/ammeter.sym} 150 -130 0 0 {name=VI2 lvs_ignore=short}}
+C {devices/ammeter.sym} -160 -40 0 0 {name=VI3 lvs_ignore=short}}
 C {devices/iopin.sym} 100 130 2 1 {name=p6 lab=CM}
 C {devices/lab_pin.sym} -120 -70 2 0 {name=p11 sig_type=std_logic lab=AVDD}
 C {devices/lab_pin.sym} 190 -160 2 0 {name=p4 sig_type=std_logic lab=AVDD}
@@ -106,8 +106,8 @@ C {devices/spice_probe.sym} -50 -90 0 0 {name=p62 attrs=""}
 C {devices/lab_pin.sym} -50 -90 2 0 {name=p12 sig_type=std_logic lab=VONEG}
 C {devices/spice_probe.sym} -50 120 0 0 {name=p13 attrs=""}
 C {devices/iopin.sym} -120 -280 0 0 {name=p7 lab=AVDD}
-C {devices/ammeter.sym} 260 -130 0 0 {name=VI1}
-C {devices/ammeter.sym} 310 -40 3 0 {name=VI4}
+C {devices/ammeter.sym} 260 -130 0 0 {name=VI1 lvs_ignore=short}}
+C {devices/ammeter.sym} 310 -40 3 0 {name=VI4 lvs_ignore=short}}
 C {Input_Stage_OA1.sym} -140 -160 0 0 {name=x1}
 C {Input_Stage_OA1.sym} -140 50 0 0 {name=x2}
 C {Input_Stage_OA2.sym} 170 -40 0 0 {name=x3}

--- a/xschem/Output_OA.sch
+++ b/xschem/Output_OA.sch
@@ -142,7 +142,7 @@ sa=0 sb=0 sd=0
 model=nfet_01v8_lvt
 spiceprefix=X
 }
-C {devices/ammeter.sym} 670 -260 0 0 {name=VISink}
+C {devices/ammeter.sym} 670 -260 0 0 {name=VISink lvs_ignore=short}}
 C {sky130_fd_pr/pfet_01v8_lvt.sym} 600 -630 0 1 {name=M6
 L=5
 W=20
@@ -171,10 +171,10 @@ sa=0 sb=0 sd=0
 model=pfet_01v8_lvt
 spiceprefix=X
 }
-C {devices/ammeter.sym} 580 -530 0 0 {name=VD1}
-C {devices/ammeter.sym} 760 -530 0 1 {name=VID2}
-C {devices/ammeter.sym} 970 -270 0 0 {name=VID1}
-C {devices/ammeter.sym} 970 -530 0 0 {name=VID3}
+C {devices/ammeter.sym} 580 -530 0 0 {name=VD1 lvs_ignore=short}}
+C {devices/ammeter.sym} 760 -530 0 1 {name=VID2 lvs_ignore=short}}
+C {devices/ammeter.sym} 970 -270 0 0 {name=VID1 lvs_ignore=short}}
+C {devices/ammeter.sym} 970 -530 0 0 {name=VID3 lvs_ignore=short}}
 C {devices/iopin.sym} 510 -360 0 1 {name=p3 lab=VINN}
 C {devices/iopin.sym} 840 -360 0 0 {name=p5 lab=VINP}
 C {devices/spice_probe.sym} 510 -360 0 0 {name=p12 attrs=""}
@@ -184,7 +184,7 @@ C {devices/spice_probe.sym} 990 -380 0 0 {name=p2 attrs=""}
 C {devices/iopin.sym} 970 -710 0 0 {name=p4 lab=VDD}
 C {devices/iopin.sym} 970 -130 0 0 {name=p6 lab=VSS}
 C {devices/iopin.sym} 500 -180 0 1 {name=p7 lab=VBIAS}
-C {devices/ammeter.sym} 560 -180 3 0 {name=VIBIAS}
+C {devices/ammeter.sym} 560 -180 3 0 {name=VIBIAS lvs_ignore=short}}
 C {sky130_fd_pr/nfet_05v0_nvt.sym} 560 -440 0 0 {name=M10
 L=2
 W=1
@@ -255,7 +255,7 @@ sa=0 sb=0 sd=0
 model=pfet_g5v0d10v5
 spiceprefix=X
 }
-C {devices/ammeter.sym} 880 -710 1 0 {name=VIVDD}
+C {devices/ammeter.sym} 880 -710 1 0 {name=VIVDD lvs_ignore=short}}
 C {sky130_fd_pr/cap_mim_m3_1.sym} 850 -550 0 0 {name=C1 model=cap_mim_m3_1 W=10 L=10 MF=15 spiceprefix=X}
 C {lab_pin.sym} 900 -510 0 1 {name=p8 sig_type=std_logic lab=VSS}
 C {sky130_fd_pr/res_high_po_0p69.sym} 900 -470 1 0 {name=R1

--- a/xschem/Parallel_10B_Block2.sch
+++ b/xschem/Parallel_10B_Block2.sch
@@ -321,23 +321,23 @@ N -580 -100 -580 -90 {
 lab=AVSS}
 N -550 -100 -550 -70 {
 lab=DVSS}
-C {devices/ammeter.sym} -190 -540 0 0 {name=VI4}
-C {devices/ammeter.sym} -260 -780 2 0 {name=VI6}
-C {devices/ammeter.sym} -1440 -840 3 0 {name=VI7}
+C {devices/ammeter.sym} -190 -540 0 0 {name=VI4 lvs_ignore=short}}
+C {devices/ammeter.sym} -260 -780 2 0 {name=VI6 lvs_ignore=short}}
+C {devices/ammeter.sym} -1440 -840 3 0 {name=VI7 lvs_ignore=short}}
 C {devices/spice_probe.sym} -40 -450 0 0 {name=p26 attrs=""}
-C {devices/ammeter.sym} -610 -610 2 0 {name=VI11}
-C {devices/ammeter.sym} -510 -610 2 1 {name=VI2}
-C {devices/ammeter.sym} -800 -610 2 0 {name=VI1}
-C {devices/ammeter.sym} -700 -610 2 1 {name=VI3}
-C {devices/ammeter.sym} -330 -670 3 0 {name=VICM1}
-C {devices/ammeter.sym} -330 -710 3 0 {name=VICM2}
-C {devices/ammeter.sym} -990 -610 2 0 {name=VI5}
-C {devices/ammeter.sym} -890 -610 2 1 {name=VI8}
-C {devices/ammeter.sym} -1180 -610 2 0 {name=VI9}
-C {devices/ammeter.sym} -1080 -610 2 1 {name=VI10}
-C {devices/ammeter.sym} -1370 -610 2 0 {name=VI12}
-C {devices/ammeter.sym} -1270 -610 2 1 {name=VI14}
-C {devices/ammeter.sym} -1500 -710 3 0 {name=VINN2}
+C {devices/ammeter.sym} -610 -610 2 0 {name=VI11 lvs_ignore=short}}
+C {devices/ammeter.sym} -510 -610 2 1 {name=VI2 lvs_ignore=short}}
+C {devices/ammeter.sym} -800 -610 2 0 {name=VI1 lvs_ignore=short}}
+C {devices/ammeter.sym} -700 -610 2 1 {name=VI3 lvs_ignore=short}}
+C {devices/ammeter.sym} -330 -670 3 0 {name=VICM1 lvs_ignore=short}}
+C {devices/ammeter.sym} -330 -710 3 0 {name=VICM2 lvs_ignore=short}}
+C {devices/ammeter.sym} -990 -610 2 0 {name=VI5 lvs_ignore=short}}
+C {devices/ammeter.sym} -890 -610 2 1 {name=VI8 lvs_ignore=short}}
+C {devices/ammeter.sym} -1180 -610 2 0 {name=VI9 lvs_ignore=short}}
+C {devices/ammeter.sym} -1080 -610 2 1 {name=VI10 lvs_ignore=short}}
+C {devices/ammeter.sym} -1370 -610 2 0 {name=VI12 lvs_ignore=short}}
+C {devices/ammeter.sym} -1270 -610 2 1 {name=VI14 lvs_ignore=short}}
+C {devices/ammeter.sym} -1500 -710 3 0 {name=VINN2 lvs_ignore=short}}
 C {devices/lab_pin.sym} -1120 -600 1 0 {name=p1 sig_type=std_logic lab=DVDD}
 C {devices/lab_pin.sym} -930 -600 1 0 {name=p3 sig_type=std_logic lab=DVDD}
 C {devices/lab_pin.sym} -740 -600 1 0 {name=p4 sig_type=std_logic lab=DVDD}
@@ -348,29 +348,29 @@ C {Universal_R_2R_Block2.sym} -1120 -510 0 0 {name=x1}
 C {Universal_R_2R_Block2.sym} -930 -510 0 0 {name=x2}
 C {Universal_R_2R_Block2.sym} -740 -510 0 0 {name=x3}
 C {Universal_R_2R_Block2.sym} -550 -510 0 0 {name=x4}
-C {devices/ammeter.sym} -1700 -800 0 0 {name=VI15}
+C {devices/ammeter.sym} -1700 -800 0 0 {name=VI15 lvs_ignore=short}}
 C {devices/lab_pin.sym} -1700 -830 0 0 {name=p8 sig_type=std_logic lab=AVDD}
-C {devices/ammeter.sym} -1440 -500 3 0 {name=VI16}
+C {devices/ammeter.sym} -1440 -500 3 0 {name=VI16 lvs_ignore=short}}
 C {devices/lab_pin.sym} -1750 -730 0 0 {name=p12 sig_type=std_logic lab=VCM}
 C {devices/spice_probe.sym} -1560 -660 0 0 {name=p15 attrs=""}
 C {devices/lab_pin.sym} -1560 -660 0 0 {name=p2 sig_type=std_logic lab=Vx1}
-C {devices/ammeter.sym} -1700 -440 0 0 {name=VI22}
+C {devices/ammeter.sym} -1700 -440 0 0 {name=VI22 lvs_ignore=short}}
 C {devices/lab_pin.sym} -1700 -470 0 0 {name=p27 sig_type=std_logic lab=AVDD}
 C {devices/lab_pin.sym} -1750 -370 0 0 {name=p28 sig_type=std_logic lab=VCM}
 C {devices/spice_probe.sym} -1560 -300 0 0 {name=p31 attrs=""}
-C {devices/ammeter.sym} -70 -620 2 0 {name=VICM3}
-C {devices/ammeter.sym} -610 -250 2 0 {name=VI17}
-C {devices/ammeter.sym} -510 -250 2 1 {name=VI18}
-C {devices/ammeter.sym} -800 -250 2 0 {name=VI19}
-C {devices/ammeter.sym} -700 -250 2 1 {name=VI20}
-C {devices/ammeter.sym} -330 -310 3 0 {name=VICM21}
-C {devices/ammeter.sym} -330 -350 3 0 {name=VICM22}
-C {devices/ammeter.sym} -990 -250 2 0 {name=VI23}
-C {devices/ammeter.sym} -890 -250 2 1 {name=VI24}
-C {devices/ammeter.sym} -1180 -250 2 0 {name=VI25}
-C {devices/ammeter.sym} -1080 -250 2 1 {name=VI26}
-C {devices/ammeter.sym} -1370 -250 2 0 {name=VI27}
-C {devices/ammeter.sym} -1270 -250 2 1 {name=VI28}
+C {devices/ammeter.sym} -70 -620 2 0 {name=VICM3 lvs_ignore=short}}
+C {devices/ammeter.sym} -610 -250 2 0 {name=VI17 lvs_ignore=short}}
+C {devices/ammeter.sym} -510 -250 2 1 {name=VI18 lvs_ignore=short}}
+C {devices/ammeter.sym} -800 -250 2 0 {name=VI19 lvs_ignore=short}}
+C {devices/ammeter.sym} -700 -250 2 1 {name=VI20 lvs_ignore=short}}
+C {devices/ammeter.sym} -330 -310 3 0 {name=VICM21 lvs_ignore=short}}
+C {devices/ammeter.sym} -330 -350 3 0 {name=VICM22 lvs_ignore=short}}
+C {devices/ammeter.sym} -990 -250 2 0 {name=VI23 lvs_ignore=short}}
+C {devices/ammeter.sym} -890 -250 2 1 {name=VI24 lvs_ignore=short}}
+C {devices/ammeter.sym} -1180 -250 2 0 {name=VI25 lvs_ignore=short}}
+C {devices/ammeter.sym} -1080 -250 2 1 {name=VI26 lvs_ignore=short}}
+C {devices/ammeter.sym} -1370 -250 2 0 {name=VI27 lvs_ignore=short}}
+C {devices/ammeter.sym} -1270 -250 2 1 {name=VI28 lvs_ignore=short}}
 C {devices/lab_pin.sym} -1310 -240 1 0 {name=p17 sig_type=std_logic lab=DVDD}
 C {devices/lab_pin.sym} -1120 -240 1 0 {name=p19 sig_type=std_logic lab=DVDD}
 C {devices/lab_pin.sym} -930 -240 1 0 {name=p20 sig_type=std_logic lab=DVDD}
@@ -381,8 +381,8 @@ C {Universal_R_2R_Block2.sym} -1120 -150 0 0 {name=x10}
 C {Universal_R_2R_Block2.sym} -930 -150 0 0 {name=x11}
 C {Universal_R_2R_Block2.sym} -740 -150 0 0 {name=x12}
 C {Universal_R_2R_Block2.sym} -550 -150 0 0 {name=x13}
-C {devices/ammeter.sym} -1440 -140 3 0 {name=VI29}
-C {devices/ammeter.sym} -1500 -350 3 0 {name=VINN1}
+C {devices/ammeter.sym} -1440 -140 3 0 {name=VI29 lvs_ignore=short}}
+C {devices/ammeter.sym} -1500 -350 3 0 {name=VINN1 lvs_ignore=short}}
 C {devices/iopin.sym} -20 -450 0 0 {name=p7 lab=VOUT}
 C {devices/iopin.sym} -260 -310 0 0 {name=p11 lab=VCM}
 C {devices/iopin.sym} -1900 -670 0 1 {name=p13 lab=VO1}

--- a/xschem/Parallel_PGA_Complete_DC.sch
+++ b/xschem/Parallel_PGA_Complete_DC.sch
@@ -179,7 +179,7 @@ C {devices/title.sym} 170 30 0 0 {name=l8 author="Phil Allen"}
 C {devices/lab_pin.sym} -470 -670 0 0 {name=p52 sig_type=std_logic lab=DVDD}
 C {devices/lab_pin.sym} -310 -490 0 1 {name=p53 sig_type=std_logic lab=V0000000001}
 C {devices/spice_probe.sym} -310 -490 0 0 {name=p55 attrs=""}
-C {devices/ammeter.sym} -340 -520 3 0 {name=VI5}
+C {devices/ammeter.sym} -340 -520 3 0 {name=VI5 lvs_ignore=short}}
 C {devices/gnd.sym} -180 -500 0 0 {name=l20 lab=GND}
 C {sky130_fd_pr/res_high_po_0p69.sym} -180 -520 3 0 {name=R6
 L=200
@@ -193,8 +193,8 @@ C {devices/lab_pin.sym} -260 -250 0 0 {name=p2 sig_type=std_logic lab=VIN}
 C {devices/spice_probe.sym} -260 -250 0 0 {name=p10 attrs=""}
 C {devices/lab_pin.sym} -670 -500 0 0 {name=p3 sig_type=std_logic lab=VIN}
 C {devices/lab_pin.sym} -670 -530 0 0 {name=p4 sig_type=std_logic lab=VCM}
-C {devices/ammeter.sym} -560 -640 0 0 {name=VI4}
-C {devices/ammeter.sym} -470 -640 0 0 {name=VI1}
+C {devices/ammeter.sym} -560 -640 0 0 {name=VI4 lvs_ignore=short}}
+C {devices/ammeter.sym} -470 -640 0 0 {name=VI1 lvs_ignore=short}}
 C {devices/gnd.sym} -470 -430 0 1 {name=l1 lab=GND}
 C {devices/gnd.sym} -560 -430 0 1 {name=l2 lab=GND}
 C {isource.sym} -730 -620 0 0 {name=I0 value=100n}

--- a/xschem/T_Gate_5V.sch
+++ b/xschem/T_Gate_5V.sch
@@ -31,10 +31,10 @@ C {devices/iopin.sym} 160 0 0 0 {name=p1 lab=PGATE}
 C {devices/iopin.sym} -30 -90 0 0 {name=p2 lab=UPPER}
 C {devices/iopin.sym} -30 90 0 0 {name=p3 lab=LOWER}
 C {devices/iopin.sym} -210 0 0 1 {name=p4 lab=NGATE}
-C {devices/ammeter.sym} -60 30 1 0 {name=VI6}
-C {devices/ammeter.sym} 20 30 3 1 {name=VI1}
-C {devices/ammeter.sym} 20 -30 1 0 {name=VI2}
-C {devices/ammeter.sym} -60 -30 3 1 {name=VI3}
+C {devices/ammeter.sym} -60 30 1 0 {name=VI6 lvs_ignore=short}}
+C {devices/ammeter.sym} 20 30 3 1 {name=VI1 lvs_ignore=short}}
+C {devices/ammeter.sym} 20 -30 1 0 {name=VI2 lvs_ignore=short}}
+C {devices/ammeter.sym} -60 -30 3 1 {name=VI3 lvs_ignore=short}}
 C {sky130_fd_pr/nfet_g5v0d10v5.sym} -130 0 0 0 {name=M1
 L=0.5
 W=1
@@ -63,9 +63,9 @@ sa=0 sb=0 sd=0
 model=pfet_g5v0d10v5
 spiceprefix=X
 }
-C {devices/ammeter.sym} -30 -60 2 0 {name=VI4}
-C {devices/ammeter.sym} -30 60 2 0 {name=VI5}
-C {devices/ammeter.sym} 130 0 1 1 {name=VI7}
-C {devices/ammeter.sym} -180 0 1 1 {name=VI8}
+C {devices/ammeter.sym} -30 -60 2 0 {name=VI4 lvs_ignore=short}}
+C {devices/ammeter.sym} -30 60 2 0 {name=VI5 lvs_ignore=short}}
+C {devices/ammeter.sym} 130 0 1 1 {name=VI7 lvs_ignore=short}}
+C {devices/ammeter.sym} -180 0 1 1 {name=VI8 lvs_ignore=short}}
 C {devices/iopin.sym} 40 -60 0 0 {name=p5 lab=AVDD}
 C {devices/iopin.sym} -100 50 0 1 {name=p6 lab=AVSS}

--- a/xschem/Universal_R_2R_Block2.sch
+++ b/xschem/Universal_R_2R_Block2.sch
@@ -82,8 +82,8 @@ C {devices/spice_probe.sym} 230 -190 0 0 {name=p44 attrs=""}
 C {T_Gate_5V.sym} 140 -290 0 1 {name=x12}
 C {T_Gate_5V.sym} 490 -290 0 0 {name=x13}
 C {devices/iopin.sym} -170 -140 0 1 {name=p4 lab=VD}
-C {devices/ammeter.sym} 230 0 2 1 {name=VI12}
-C {devices/ammeter.sym} 290 50 3 0 {name=VI1}
+C {devices/ammeter.sym} 230 0 2 1 {name=VI12 lvs_ignore=short}}
+C {devices/ammeter.sym} 290 50 3 0 {name=VI1 lvs_ignore=short}}
 C {devices/iopin.sym} 350 50 0 0 {name=p1 lab=R2ROUT}
 C {devices/iopin.sym} 70 50 0 1 {name=p2 lab=R2RIN}
 C {devices/iopin.sym} 130 -460 1 1 {name=p7 lab=VIRTOUT}
@@ -92,9 +92,9 @@ C {devices/iopin.sym} -170 0 0 1 {name=p9 lab=DVDD}
 C {devices/spice_probe.sym} 390 -300 0 0 {name=p11 attrs=""}
 C {devices/lab_pin.sym} 240 -300 0 1 {name=p3 sig_type=std_logic lab=VDbuf}
 C {devices/spice_probe.sym} 240 -300 0 0 {name=p5 attrs=""}
-C {devices/ammeter.sym} 500 -410 2 1 {name=VI2}
-C {devices/ammeter.sym} 130 -410 2 1 {name=VI3}
-C {devices/ammeter.sym} 110 50 3 0 {name=VI4}
+C {devices/ammeter.sym} 500 -410 2 1 {name=VI2 lvs_ignore=short}}
+C {devices/ammeter.sym} 130 -410 2 1 {name=VI3 lvs_ignore=short}}
+C {devices/ammeter.sym} 110 50 3 0 {name=VI4 lvs_ignore=short}}
 C {devices/iopin.sym} 70 120 0 1 {name=p6 lab=AVSS}
 C {lab_pin.sym} 180 120 0 1 {name=p12 sig_type=std_logic lab=AVSS}
 C {lab_pin.sym} 200 -160 0 0 {name=p13 sig_type=std_logic lab=AVSS}

--- a/xschem/sky130_pa_ip__instramp.sch
+++ b/xschem/sky130_pa_ip__instramp.sch
@@ -81,7 +81,7 @@ lab=VCM}
 N 370 -310 390 -310 {
 lab=VBIAS}
 N 570 -280 600 -280 {
-lab=VINP}
+lab=VINN}
 C {Parallel_10B_Block2.sym} 1030 -300 0 0 {name=x1}
 C {devices/title.sym} 180 10 0 0 {name=l8 author="Phil Allen"}
 C {devices/lab_pin.sym} 690 -420 0 0 {name=p51 sig_type=std_logic lab=AVDD}
@@ -91,7 +91,7 @@ C {devices/lab_pin.sym} 960 -410 0 0 {name=p1 sig_type=std_logic lab=AVDD}
 C {devices/lab_pin.sym} 850 -260 0 0 {name=p6 sig_type=std_logic lab=VO1}
 C {devices/lab_pin.sym} 690 -220 0 0 {name=p8 sig_type=std_logic lab=VCM}
 C {Input_Stage_v1.sym} 690 -300 0 0 {name=x2}
-C {devices/ammeter.sym} 690 -390 0 0 {name=VI2}
+C {devices/ammeter.sym} 690 -390 0 0 {name=VI2 lvs_ignore=short}}
 C {vbias_gen_pga.sym} 280 -310 0 0 {name=x3}
 C {lab_pin.sym} 390 -310 0 1 {name=p9 sig_type=std_logic lab=VBIAS}
 C {lab_pin.sym} 1110 -370 0 1 {name=p13 sig_type=std_logic lab=VBIAS}

--- a/xschem/vbias_gen_pga.sch
+++ b/xschem/vbias_gen_pga.sch
@@ -28,7 +28,7 @@ C {devices/iopin.sym} -60 180 0 0 {name=p1 lab=VBIAS}
 C {devices/spice_probe.sym} -150 180 0 0 {name=p2 attrs=""}
 C {devices/iopin.sym} -250 270 0 0 {name=p6 lab=VSS}
 C {devices/iopin.sym} -450 120 0 1 {name=p7 lab=IBIAS}
-C {devices/ammeter.sym} -320 120 3 0 {name=VIBIAS}
+C {devices/ammeter.sym} -320 120 3 0 {name=VIBIAS lvs_ignore=short}}
 C {sky130_fd_pr/nfet_g5v0d10v5.sym} -230 180 0 1 {name=M4
 L=1
 W=5

--- a/xschem/x1_x32_OA.sch
+++ b/xschem/x1_x32_OA.sch
@@ -143,7 +143,7 @@ sa=0 sb=0 sd=0
 model=nfet_01v8_lvt
 spiceprefix=X
 }
-C {devices/ammeter.sym} -20 140 0 0 {name=VISink}
+C {devices/ammeter.sym} -20 140 0 0 {name=VISink lvs_ignore=short}}
 C {sky130_fd_pr/pfet_01v8_lvt.sym} -90 -230 0 1 {name=M6
 L=5
 W=20
@@ -172,10 +172,10 @@ sa=0 sb=0 sd=0
 model=pfet_01v8_lvt
 spiceprefix=X
 }
-C {devices/ammeter.sym} -110 -130 0 0 {name=VD1}
-C {devices/ammeter.sym} 70 -130 0 1 {name=VID2}
-C {devices/ammeter.sym} 280 130 0 0 {name=VID1}
-C {devices/ammeter.sym} 280 -130 0 0 {name=VID3}
+C {devices/ammeter.sym} -110 -130 0 0 {name=VD1 lvs_ignore=short}}
+C {devices/ammeter.sym} 70 -130 0 1 {name=VID2 lvs_ignore=short}}
+C {devices/ammeter.sym} 280 130 0 0 {name=VID1 lvs_ignore=short}}
+C {devices/ammeter.sym} 280 -130 0 0 {name=VID3 lvs_ignore=short}}
 C {devices/iopin.sym} -180 40 0 1 {name=p3 lab=VINN}
 C {devices/iopin.sym} 150 40 0 0 {name=p5 lab=VINP}
 C {devices/spice_probe.sym} -180 40 0 1 {name=p12 attrs=""}
@@ -185,7 +185,7 @@ C {devices/spice_probe.sym} 300 20 0 0 {name=p2 attrs=""}
 C {devices/iopin.sym} 280 -310 0 0 {name=p4 lab=VDD}
 C {devices/iopin.sym} 280 270 0 0 {name=p6 lab=VSS}
 C {devices/iopin.sym} -180 220 0 1 {name=p7 lab=VBIAS}
-C {devices/ammeter.sym} -130 220 3 0 {name=VIBIAS}
+C {devices/ammeter.sym} -130 220 3 0 {name=VIBIAS lvs_ignore=short}}
 C {sky130_fd_pr/nfet_05v0_nvt.sym} -130 -40 0 0 {name=M10
 L=2
 W=1
@@ -256,7 +256,7 @@ sa=0 sb=0 sd=0
 model=pfet_g5v0d10v5
 spiceprefix=X
 }
-C {devices/ammeter.sym} 190 -310 1 0 {name=VIVDD}
+C {devices/ammeter.sym} 190 -310 1 0 {name=VIVDD lvs_ignore=short}}
 C {sky130_fd_pr/cap_mim_m3_1.sym} 160 -150 0 0 {name=C1 model=cap_mim_m3_1 W=10 L=10 MF=15 spiceprefix=X}
 C {lab_pin.sym} 230 -110 0 1 {name=p8 sig_type=std_logic lab=VSS}
 C {sky130_fd_pr/res_high_po_0p69.sym} 210 -70 1 0 {name=R1


### PR DESCRIPTION
@RTimothyEdwards Another change to short ammeters in LVS netlists.

There is a net discrepancy in `sky130_pa_ip__instramp.sch` at line 84. I don't know if this is a xschem version problem, but the new version matches the attached pin.